### PR TITLE
Support building test client on non-windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,47 +2,58 @@ cmake_minimum_required(VERSION 3.15)
 
 project(boost-asio-windows-sspi)
 
-set(Boost_USE_STATIC_LIBS ON)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-set(BOOST_ROOT "C:/boost_1_73_0/")
-set(BOOST_LIBRARYDIR "C:/boost_1_73_0/lib/")
+if (WIN32)
+  set(Boost_USE_STATIC_LIBS ON)
+  set(Boost_USE_MULTITHREADED ON)
+  set(Boost_USE_STATIC_RUNTIME OFF)
+  set(BOOST_ROOT "C:/boost_1_73_0/")
+  set(BOOST_LIBRARYDIR "C:/boost_1_73_0/lib/")
+endif()
 
 find_package(Boost REQUIRED COMPONENTS date_time regex)
 
 add_executable(https_client https_client.cpp)
 target_link_libraries(https_client PRIVATE
-    Boost::headers
-    Boost::date_time
-    Boost::regex
+  Boost::headers
+  Boost::date_time
+  Boost::regex
+  )
+
+if (WIN32)
+  target_link_libraries(https_client PRIVATE
     Crypt32
     Secur32
     )
 
-set(MSVC_WARNINGS
-      /W4 # Baseline reasonable warnings
-      /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-      /w14263 # 'function': member function does not override any base class virtual member function
-      /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
-              # be destructed correctly
-      /w14287 # 'operator': unsigned/negative constant mismatch
-      /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
-              # the for-loop scope
-      /w14296 # 'operator': expression is always 'boolean_value'
-      /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
-      /w14545 # expression before comma evaluates to a function which is missing an argument list
-      /w14546 # function call before comma missing argument list
-      /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
-      /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
-      /w14555 # expression has no effect; expected expression with side- effect
-      /w14640 # Enable warning on thread un-safe static member initialization
-      /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
-      /w14905 # wide string literal cast to 'LPSTR'
-      /w14906 # string literal cast to 'LPWSTR'
-      /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
-      /permissive- # standards conformance mode for MSVC compiler.
-      /WX
-      )
+  set(MSVC_WARNINGS
+    /W4 # Baseline reasonable warnings
+    /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+    /w14263 # 'function': member function does not override any base class virtual member function
+    /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not be destructed correctly
+    /w14287 # 'operator': unsigned/negative constant mismatch
+    /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside the for-loop scope
+    /w14296 # 'operator': expression is always 'boolean_value'
+    /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+    /w14545 # expression before comma evaluates to a function which is missing an argument list
+    /w14546 # function call before comma missing argument list
+    /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+    /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+    /w14555 # expression has no effect; expected expression with side- effect
+    /w14640 # Enable warning on thread un-safe static member initialization
+    /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+    /w14905 # wide string literal cast to 'LPSTR'
+    /w14906 # string literal cast to 'LPWSTR'
+    /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+    /permissive- # standards conformance mode for MSVC compiler.
+    /WX
+    )
 
-target_include_directories(https_client PRIVATE include)
-target_compile_options(https_client PRIVATE ${MSVC_WARNINGS})
+  target_include_directories(https_client PRIVATE include)
+  target_compile_options(https_client PRIVATE ${MSVC_WARNINGS})
+else()
+  target_link_libraries(https_client PRIVATE
+    pthread
+    crypto
+    ssl
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ if (WIN32)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_MULTITHREADED ON)
   set(Boost_USE_STATIC_RUNTIME OFF)
-  set(BOOST_ROOT "C:/boost_1_73_0/")
-  set(BOOST_LIBRARYDIR "C:/boost_1_73_0/lib/")
 endif()
 
 find_package(Boost REQUIRED COMPONENTS date_time regex)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if (WIN32)
     Secur32
     )
 
+  # Taken from https://github.com/lefticus/cpp_starter_project
   set(MSVC_WARNINGS
     /W4 # Baseline reasonable warnings
     /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data

--- a/https_client.cpp
+++ b/https_client.cpp
@@ -1,13 +1,26 @@
-#include <SDKDDKVer.h>
+#ifdef _WIN32
+# include <SDKDDKVer.h>
+#endif
 
 #include <boost/asio.hpp>
-#include <boost/asio/windows_sspi.hpp>
+
+#ifdef _WIN32
+# include <boost/asio/windows_sspi.hpp>
+#else
+# include <boost/asio/ssl.hpp>
+#endif
 
 #include <cstdlib>
 #include <iostream>
 #include <iterator>
 #include <string>
 #include <fstream>
+
+#ifdef _WIN32
+namespace ssl = boost::asio::windows_sspi;
+#else
+namespace ssl = boost::asio::ssl;
+#endif
 
 using boost::asio::ip::tcp;
 
@@ -45,12 +58,12 @@ int main(int argc, char *argv[]) {
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
     // Try each endpoint until we successfully establish a connection.
-    boost::asio::windows_sspi::context ctx;
-    boost::asio::windows_sspi::stream<boost::asio::ip::tcp::socket> socket(io_service, ctx);
+    ssl::context ctx{ssl::context::sslv23};
+    ssl::stream<boost::asio::ip::tcp::socket> socket(io_service, ctx);
 
     boost::asio::connect(socket.lowest_layer(), endpoint_iterator);
 
-    socket.handshake(boost::asio::windows_sspi::stream_base::client);
+    socket.handshake(ssl::stream_base::client);
     // Form the request. We specify the "Connection: close" header so that the
     // server will close the socket after transmitting the response. This will
     // allow us to treat all data up until the EOF as the content.

--- a/include/boost/asio/windows_sspi/context.hpp
+++ b/include/boost/asio/windows_sspi/context.hpp
@@ -12,6 +12,7 @@
 #define BOOST_ASIO_WINDOWS_SSPI_CONTEXT_HPP
 
 #include "error.hpp"
+#include "context_base.hpp"
 
 // TODO: Avoid cluttering global namespace (and avoid Windows headers if possible)
 #define SECURITY_WIN32
@@ -25,25 +26,25 @@ namespace boost {
 namespace asio {
 namespace windows_sspi {
 
-class context
+class context : public context_base
 {
 public:
     using native_handle_type = CredHandle;
     using error_code = boost::system::error_code;
 
-    context()
-        : m_impl(std::make_shared<impl>())
+    explicit context(method m)
+        : m_impl(std::make_shared<impl>(m))
     {}
 
 private:
     struct impl
     {
-        impl()
+        explicit impl(method)
             : sspi_functions(InitSecurityInterface())
         {
             SCHANNEL_CRED creds{};
             creds.dwVersion = SCHANNEL_CRED_VERSION;
-            // TODO: Set protocols to enable
+            // TODO: Set protocols to enable from method param
             creds.grbitEnabledProtocols = 0;
             // TODO: Set proper flags based on options. This basically disables certificate validation.
             creds.dwFlags = SCH_CRED_MANUAL_CRED_VALIDATION | SCH_CRED_NO_SERVERNAME_CHECK;

--- a/include/boost/asio/windows_sspi/context_base.hpp
+++ b/include/boost/asio/windows_sspi/context_base.hpp
@@ -1,0 +1,103 @@
+//
+// windows_sspi/context_base.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2020 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_ASIO_WINDOWS_SSPI_CONTEXT_BASE_HPP
+#define BOOST_ASIO_WINDOWS_SSPI_CONTEXT_BASE_HPP
+
+namespace boost {
+namespace asio {
+namespace windows_sspi {
+
+class context_base
+{
+public:
+  /// Different methods supported by a context.
+  // TODO: Map to grbitEnabledProtocols member of SCHANNEL_CRED struct (and acutally use it).
+  enum method
+  {
+    /// Generic SSL version 2.
+    sslv2,
+
+    /// SSL version 2 client.
+    sslv2_client,
+
+    /// SSL version 2 server.
+    sslv2_server,
+
+    /// Generic SSL version 3.
+    sslv3,
+
+    /// SSL version 3 client.
+    sslv3_client,
+
+    /// SSL version 3 server.
+    sslv3_server,
+
+    /// Generic TLS version 1.
+    tlsv1,
+
+    /// TLS version 1 client.
+    tlsv1_client,
+
+    /// TLS version 1 server.
+    tlsv1_server,
+
+    /// Generic SSL/TLS.
+    sslv23,
+
+    /// SSL/TLS client.
+    sslv23_client,
+
+    /// SSL/TLS server.
+    sslv23_server,
+
+    /// Generic TLS version 1.1.
+    tlsv11,
+
+    /// TLS version 1.1 client.
+    tlsv11_client,
+
+    /// TLS version 1.1 server.
+    tlsv11_server,
+
+    /// Generic TLS version 1.2.
+    tlsv12,
+
+    /// TLS version 1.2 client.
+    tlsv12_client,
+
+    /// TLS version 1.2 server.
+    tlsv12_server,
+
+    /// Generic TLS version 1.3.
+    tlsv13,
+
+    /// TLS version 1.3 client.
+    tlsv13_client,
+
+    /// TLS version 1.3 server.
+    tlsv13_server,
+
+    /// Generic TLS.
+    tls,
+
+    /// TLS client.
+    tls_client,
+
+    /// TLS server.
+    tls_server
+  };
+};
+
+} // namespace windows_sspi
+} // namespace asio
+} // namespace boost
+
+#endif // BOOST_ASIO_WINDOWS_SSPI_CONTEXT_BASE_HPP


### PR DESCRIPTION
Fix CMake build script to link with openssl on non-windows platforms
and add some ugly ifdefs in the very primitive https_client to alias
the ssl namespace to either the asio::ssl namespace I'm trying to
mimick or my new namespace.

Also add an unused method enum and constructor arguement to the
context constructor to mirror the interface of the original
asio::ssl::context constructor.

This is to have some easy way of comparing results/behavior during
implementation.